### PR TITLE
Declare and target missing dependencies

### DIFF
--- a/dynmsg_demo/CMakeLists.txt
+++ b/dynmsg_demo/CMakeLists.txt
@@ -62,6 +62,7 @@ if(BUILD_TESTING)
   find_package(example_interfaces REQUIRED)
   find_package(dynmsg_msgs REQUIRED)
   find_package(geometry_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
 
   if (TEST_ASAN)
     set(asan_link_lib -fsanitize=address)
@@ -75,6 +76,7 @@ if(BUILD_TESTING)
   ament_target_dependencies(msg_parser_test
     rcl
     test_msgs
+    std_msgs
     dynmsg_msgs
     )
   ament_add_gtest(wide_strings test/test_wide_strings.cpp)

--- a/dynmsg_demo/package.xml
+++ b/dynmsg_demo/package.xml
@@ -12,10 +12,14 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rcl</depend>
+  <depend>rcl_action</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>dynmsg_msgs</test_depend>
+  <test_depend>example_interfaces</test_depend>
+  <test_depend>geometry_msgs</test_depend>
+  <test_depend>std_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
Otherwise builds fail because of missing dependencies.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>